### PR TITLE
Remove timers when extension is finalized

### DIFF
--- a/timer/src/timer.cpp
+++ b/timer/src/timer.cpp
@@ -302,6 +302,10 @@ dmExtension::Result UpdateTimerExtension(dmExtension::Params* params) {
 }
 
 dmExtension::Result FinalizeTimerExtension(dmExtension::Params* params) {
+	while(!g_Timers.Empty()) {
+		Timer* timer = g_Timers.Back();
+		Remove(timer->id);
+	}
 	return dmExtension::RESULT_OK;
 }
 


### PR DESCRIPTION
This seems to fix the rebuild crashes that I've been seeing from time to time